### PR TITLE
DP-3309 Sending empty strings instead of undefined in credentials for MQTT.

### DIFF
--- a/api/mqtt/connector.js
+++ b/api/mqtt/connector.js
@@ -35,8 +35,8 @@ function Broker(conf, logger) {
     me.secure = conf.secure;
     me.keepalive = conf.keepalive || 60;
     me.crd = {
-        username: conf.username,
-        password: conf.password
+        username: conf.username || '',
+        password: conf.password || ''
     };
     if(conf.strictSSL === undefined || conf.strictSSL === true) {
         me.crd.ca = trustedCAs;
@@ -57,8 +57,8 @@ function Broker(conf, logger) {
     me.setCredential = function (newCrd) {
         me.crd = newCrd || me.crd;
         me.credential = {
-            username: me.crd.username,
-            password: me.crd.password,
+            username: me.crd.username || '',
+            password: me.crd.password || '',
             keepalive: me.keepalive
         };
         if(conf.strictSSL === undefined || conf.strictSSL === true) {

--- a/lib/proxies/iot.mqtt.js
+++ b/lib/proxies/iot.mqtt.js
@@ -209,8 +209,8 @@ IoTKitMQTTCloud.prototype.health = function (device, callback) {
 IoTKitMQTTCloud.prototype.setCredential = function (user, password) {
     var me = this;
     me.crd = {
-        username: user,
-        password: password
+        username: user || '',
+        password: password || ''
     };
     me.client.disconnect();
     me.client.setCredential(me.crd);

--- a/lib/proxies/iot.rest.js
+++ b/lib/proxies/iot.rest.js
@@ -191,8 +191,8 @@ IoTKitRestCloud.prototype.getCatalog = function (data, callback) {
 IoTKitRestCloud.prototype.setCredential = function (user, password) {
     var me = this;
     me.crd = {
-        username: user,
-        password: password
+        username: user || '',
+        password: password || ''
     };
     me.logger.debug("The user is: ", user , " and password ", password);
 };


### PR DESCRIPTION
 Sending empty strings instead of undefined in credentials for MQTT.
