### PR TITLE
DP-3645 Fix search for user.js to handle relative data_directory paths

### DIFF
--- a/admin/configurator.js
+++ b/admin/configurator.js
@@ -189,8 +189,8 @@ var moveDataDirectory = function(directory, cb) {
 var setDataDirectory = function(directory, cb){
     fs.exists(directory, function (exists) {
         if(exists){
-            fs.exists(path.resolve(directory, "device.json"), function(configExsits){
-                if(configExsits){
+            fs.exists(path.resolve(directory, "device.json"), function(configExists) {
+                if(configExists){
                     common.saveToGlobalConfig(configFileKey.dataDirectory, path.resolve(directory));
                 }
                 else{

--- a/config/global.json
+++ b/config/global.json
@@ -1,5 +1,5 @@
 {
-    "data_directory": "./data/",
+    "data_directory": "./data",
     "listeners": {
         "mqtt_port": 1884,
         "rest_port": 9090,

--- a/config/index.js
+++ b/config/index.js
@@ -30,10 +30,19 @@ var fs = require('fs'),
     localConf = "./global.json";
 
 var config = {};
+var userConfig = '';
+
+function isAbsolutePath(location) { // Change to path.isAbsolute when upgrading Node.js
+    return path.resolve(location) === path.normalize(location);
+}
 
 if (fs.existsSync(path.join(__dirname, localConf))) {
     config = require(localConf);
-    var userConfig = path.resolve(config['data_directory'], 'user.js');
+    if(isAbsolutePath(config['data_directory'])) {
+        userConfig = path.resolve(config['data_directory'], 'user.js');
+    } else {
+        userConfig = path.resolve(__dirname, "..", config['data_directory'], 'user.js');
+    }
     if(fs.existsSync(userConfig)){
         config = require(userConfig);
     }

--- a/data/user.js
+++ b/data/user.js
@@ -30,7 +30,7 @@ var fs = require('fs'),
     path = require('path'),
     localConf = path.resolve(fs.realpathSync(process.argv[1]), "../config/global.json");
 
-if (!fs.exists(localConf)) {
+if (!fs.existsSync(localConf)) {
     localConf = path.resolve("config/global.json");
 }
 
@@ -39,7 +39,8 @@ var config = {};
 if (fs.existsSync(localConf)) {
     config = require(localConf);
 } else {
-    console.error("Failed to find config file");
+    console.error("Failed to find config file in ", localConf);
+    console.error("Run your command from directory", path.dirname(fs.realpathSync(process.argv[1])));
     process.exit(0);
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -149,10 +149,26 @@ module.exports.buildPath = function (path, data) {
     return pathReplace;
 };
 
+module.exports.isAbsolutePath = function(location) {
+    return path.resolve(location) === path.normalize(location);
+};
+
+module.exports.getFileFromDataDirectory = function(filename) {
+    var config = this.readConfig(path.join(__dirname,"../config/global.json"));
+    var fullFileName = '';
+    if(config) {
+        var dataDirectory = config['data_directory'];
+        if (module.exports.isAbsolutePath(dataDirectory)) {
+            fullFileName = path.resolve(dataDirectory, filename);
+        } else {
+            fullFileName = path.resolve(__dirname, "..", dataDirectory, filename);
+        }
+    }
+    return fullFileName;
+};
+
 module.exports.getDeviceConfigName = function() {
-    var config = this.getConfig();
-    var dataDirectory = config['data_directory'];
-    var fullFileName = path.join(dataDirectory , "device.json");
+    var fullFileName = module.exports.getFileFromDataDirectory('device.json');
     if (fs.existsSync(fullFileName)) {
         return fullFileName;
     } else {
@@ -177,7 +193,7 @@ module.exports.getConfig = function(){
         return require(process.userConfigPath);
     }else{
         var config = this.readConfig(path.join(__dirname,"../config/global.json"));
-        var userConfig = path.resolve(config["data_directory"], "user.js");
+        var userConfig = module.exports.getFileFromDataDirectory('user.js');
         if(fs.existsSync(userConfig)){
             return require(userConfig);
         }
@@ -231,8 +247,7 @@ module.exports.saveToGlobalConfig = function(key, value){
 module.exports.saveToUserConfig = function(key, value){
     var config = this.getConfig();
     if(config) {
-        var dataDirectory = config['data_directory'];
-        var userConfig = (process.userConfigPath) ? process.userConfigPath : path.join(dataDirectory, "user.js") ;
+        var userConfig = (process.userConfigPath) ? process.userConfigPath : module.exports.getFileFromDataDirectory('user.js');
         var file = fs.readFileSync(path.resolve(userConfig), 'utf8');
         var filter = new RegExp("\nconfig." + key + "\\s*=.*;");
         if (filter.test(file)) {


### PR DESCRIPTION
When searching for user.js to write, the current logic can't handle relative paths in the data_directory setting. This causes the "protocol" iotkit-admin command to break when using the default data directory (./data/).