### PR TITLE
DP-3931: Adding new command to iotkit-admin.js for setting actual time.

### DIFF
--- a/api/cloud.proxy.js
+++ b/api/cloud.proxy.js
@@ -281,6 +281,14 @@ IoTKitCloud.prototype.pullActuations = function () {
     });
 };
 
+IoTKitCloud.prototype.getActualTime = function (callback) {
+    var me = this;
+    me.proxy.getActualTime(function (result) {
+        me.logger.debug("Response ", result);
+        callback(result);
+    });
+};
+
 exports.init = function(logger, deviceId) {
     return new IoTKitCloud(logger, deviceId);
 };

--- a/api/rest/admin.def.js
+++ b/api/rest/admin.def.js
@@ -65,6 +65,14 @@ ExternalInfoOption.prototype = new ConnectionOptions();
 ExternalInfoOption.prototype.constructor = ExternalInfoOption;
 IoTKiT.ExternalInfoOption = ExternalInfoOption;
 
-
+function TimeOption() {
+    this.pathname = apiconf.path.time;
+    this.token = null;
+    ConnectionOptions.call(this);
+    this.method = GET_METHOD;
+}
+TimeOption.prototype = new ConnectionOptions();
+TimeOption.prototype.constructor = TimeOption;
+IoTKiT.TimeOption = TimeOption;
 
 module.exports = IoTKiT;

--- a/api/rest/iot.admin.js
+++ b/api/rest/iot.admin.js
@@ -50,3 +50,7 @@ module.exports.getExternalInfo = function (callback) {
     var external = new AdminDef.ExternalInfoOption();
     return httpClient.httpRequest(external, callback);
 };
+module.exports.getActualTime = function (callback) {
+    var time = new AdminDef.TimeOption();
+    return httpClient.httpRequest(time, callback);
+};

--- a/config/global.json
+++ b/config/global.json
@@ -64,7 +64,8 @@
                     "catalog": "/v1/api/cmpcatalog",
                     "component": "/v1/api/cmpcatalog/{componentId}"
                 },
-                "health": "/v1/api/health"
+                "health": "/v1/api/health",
+                "time": "/v1/api/time"
             }
         },
         "ws": {

--- a/lib/proxies/iot.mqtt.js
+++ b/lib/proxies/iot.mqtt.js
@@ -232,6 +232,11 @@ IoTKitMQTTCloud.prototype.setCredential = function (user, password) {
 
     me.client.setCredential(me.crd);
 };
+IoTKitMQTTCloud.prototype.getActualTime = function (callback) {
+    var me = this;
+    me.logger.error('This option is not currently supported for MQTT protocol.');
+    callback(null);
+};
 
 module.exports.init = function(conf, logger) {
     var brokerConnector = Broker.singleton(conf.connector.mqtt, logger);

--- a/lib/proxies/iot.rest.js
+++ b/lib/proxies/iot.rest.js
@@ -212,6 +212,19 @@ IoTKitRestCloud.prototype.setCredential = function (user, password) {
     me.logger.debug("The user is: ", user , " and password ", password);
 };
 
+IoTKitRestCloud.prototype.getActualTime = function (callback) {
+    var me = this;
+    me.logger.info("Starting Time Retrieving ");
+    me.client.admin.getActualTime(function (err, response) {
+        if (!err && response) {
+            me.logger.debug("Response From Time Retrieving", response);
+            callback(response.actualTime);
+        } else {
+            me.logger.error("Time Retrieved Error ", err);
+            callback(null);
+        }
+    });
+};
 
 
 module.exports.init = function(conf, logger) {


### PR DESCRIPTION
Important:

This task has been done specially for devices other then Edison. Edison has build in system time synchronization.
If you want to test this command on Edison, you first need to disable it.
Here is some test example:

systemctl stop systemd-timesyncd
date -u "2015-03-17 15:15:15"
date // displays date set previously
./iotkit-admin set-date
date // displays current date in IoTCloud

I attach image from date command documentation with highlighted date format that I used and others valid.
![date](https://cloud.githubusercontent.com/assets/9005909/6729499/3d745fde-ce33-11e4-93b4-132aad3c1d72.jpg)
