### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/sensors-store.js
+++ b/lib/sensors-store.js
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 require('es6-shim');
 var common = require("./common"),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 function Sensor (store, logT) {
     var me = this;

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "description": "Edge agent to abstract complexities",
   "main": "server.js",
   "dependencies": {
+    "async": "^0.9.0",
+    "cli-table": "^0.3.0",
+    "es6-shim": "0.34.0",
     "express": "^3.5.2",
     "getmac": "^1.0.6",
     "json-schema": "^0.2.2",
-    "mqtt": "^0.3.8",
-    "node-uuid": "^1.4.1",
-    "request": "^2.36.0",
-    "async": "^0.9.0",
-    "winston": "^0.7.3",
-    "cli-table": "^0.3.0",
     "json-socket": "^0.1.2",
-    "websocket": "^1.0.18",
+    "mqtt": "^0.3.8",
+    "request": "^2.36.0",
     "tunnel": "0.0.3",
-    "es6-shim": "0.34.0"
+    "uuid": "^3.0.0",
+    "websocket": "^1.0.18",
+    "winston": "^0.7.3"
   },
   "bin": {
     "iotkit-admin": "./iotkit-admin.js",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.